### PR TITLE
Fix if() statement in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ if (NOT DEFINED BIOMETRYD_VERSION_MAJOR)
   #   - other distros
   #   - errors
   # we define the version to be 0.0.1
-  if (${DISTRO_CODENAME} STREQUAL "vivid")
+  if ("${DISTRO_CODENAME}" STREQUAL "vivid")
     set(BIOMETRYD_VERSION_MAJOR 0)
     set(BIOMETRYD_VERSION_MINOR 0)
     set(BIOMETRYD_VERSION_PATCH 1)


### PR DESCRIPTION
Since cmake 3.1, variables are not anymore implicitly converted to string in if() statement which cause a build error with the "STREQUAL". See https://cmake.org/cmake/help/v3.1/policy/CMP0054.html for more informations.